### PR TITLE
Build fixes for snowman to build on OS X

### DIFF
--- a/src/nc/common/CancellationToken.h
+++ b/src/nc/common/CancellationToken.h
@@ -58,7 +58,7 @@ public:
      * Creates a not canceled token.
      */
     CancellationToken():
-        cancellationRequested_(std::make_shared<volatile bool>(false))
+        cancellationRequested_(new bool(false))
     {}
 
     /**

--- a/src/nc/core/Context.cpp
+++ b/src/nc/core/Context.cpp
@@ -46,7 +46,7 @@ namespace core {
 
 Context::Context():
     image_(std::make_shared<image::Image>()),
-    instructions_(std::make_shared<const arch::Instructions>())
+    instructions_(new arch::Instructions())
 {}
 
 Context::~Context() {}

--- a/src/nc/gui/Project.cpp
+++ b/src/nc/gui/Project.cpp
@@ -46,7 +46,7 @@ namespace gui {
 Project::Project(QObject *parent):
     QObject(parent),
     image_(std::make_shared<core::image::Image>()),
-    instructions_(std::make_shared<const core::arch::Instructions>()),
+    instructions_(new core::arch::Instructions()),
     context_(std::make_shared<core::Context>()),
     commandQueue_(new CommandQueue(this))
 {


### PR DESCRIPTION
Apparently there are some issues with the usage of `std::make_shared`,
so instead we just use the `shared_ptr`'s constructor directly with `new`.