### PR TITLE
fixed a bug with string -> number conversion

### DIFF
--- a/src/nc/common/StringToInt.cpp
+++ b/src/nc/common/StringToInt.cpp
@@ -7,13 +7,13 @@ namespace nc {
 
 namespace {
 
-#define NC_CONVERSION_TABLE(CONVERSION)     \
-    CONVERSION(toInt, int)                  \
-    CONVERSION(toUInt, unsigned int)        \
-    CONVERSION(toLong, long)                \
-    CONVERSION(toULong, unsigned long)      \
-    CONVERSION(toLong, long long)           \
-    CONVERSION(toULong, unsigned long long)
+#define NC_CONVERSION_TABLE(CONVERSION)         \
+    CONVERSION(toInt, int)                      \
+    CONVERSION(toUInt, unsigned int)            \
+    CONVERSION(toLong, long)                    \
+    CONVERSION(toULong, unsigned long)          \
+    CONVERSION(toLongLong, long long)           \
+    CONVERSION(toULongLong, unsigned long long)
 
 #define NC_CONVERSION_FUNCTION(METHOD, TYPE)                            \
     inline bool stringToInt(const QString &s, int base, TYPE &result) { \


### PR DESCRIPTION
On Windows x64 the conversion function would call `toLong` and `toULong` which 32 bits wide and no 64 as expected.