### PR TITLE
More flag ops, more rules for Simplifier

### DIFF
--- a/src/nc/arch/x86/X86InstructionAnalyzer.cpp
+++ b/src/nc/arch/x86/X86InstructionAnalyzer.cpp
@@ -133,49 +133,36 @@ public:
         /* Describing semantics */
         switch (ud_obj_.mnemonic) {
             case UD_Iadc: {
-#define adc_bitness(bitness) if(operand(0).size() == bitness)\
-                _[\
-                    regizter(X86Registers::tmp##bitness ()) ^= operand(0) + operand(1) + zero_extend(cf),\
-                    cf ^= unsigned_(regizter(X86Registers::tmp##bitness ())) < unsigned_(operand(0)),\
-                    operand(0) ^= regizter(X86Registers::tmp##bitness ()),\
-                    pf ^= intrinsic(),\
-                    zf ^= operand(0) == constant(0),\
-                    sf ^= signed_(operand(0)) < constant(0),\
-                    of ^= intrinsic(),\
-                    af ^= intrinsic(),\
-                    less ^= ~(sf == of),\
-                    less_or_equal ^= less | zf,\
+                _[
+                    temporary(operand(0).size()) ^= operand(0) + operand(1) + zero_extend(cf),
+                    cf ^= unsigned_(temporary(operand(0).size())) < unsigned_(operand(0)),
+                    operand(0) ^= temporary(operand(0).size()),
+                    pf ^= intrinsic(),
+                    zf ^= operand(0) == constant(0),
+                    sf ^= signed_(operand(0)) < constant(0),
+                    of ^= intrinsic(),
+                    af ^= intrinsic(),
+                    less ^= ~(sf == of),
+                    less_or_equal ^= less | zf,
                     below_or_equal ^= cf | zf\
-                ]; else{}
-
-                adc_bitness(8);
-                adc_bitness(16);
-                adc_bitness(32);
-                adc_bitness(64);
-#undef adc_bitness
+                ];
                 break;
             }
             case UD_Iadd: {
-#define add_bitness(bitness) if(operand(0).size() == bitness)\
-                _[\
-                    regizter(X86Registers::tmp##bitness ()) ^= operand(0) + operand(1),\
-                    cf ^= unsigned_(regizter(X86Registers::tmp##bitness ())) < unsigned_(operand(0)),\
-                    operand(0) ^= regizter(X86Registers::tmp##bitness ()),\
-                    pf ^= intrinsic(),\
-                    zf ^= operand(0) == constant(0),\
-                    sf ^= signed_(operand(0)) < constant(0),\
-                    of ^= intrinsic(),\
-                    af ^= intrinsic(),\
-                    less ^= ~(sf == of),\
-                    less_or_equal ^= less | zf,\
-                    below_or_equal ^= cf | zf\
-                ]; else{}
-                add_bitness(8);
-                add_bitness(16);
-                add_bitness(32);
-                add_bitness(64);
+                _[
+                        temporary(operand(0).size()) ^= operand(0) + operand(1),
+                        cf ^= unsigned_(temporary(operand(0).size())) < unsigned_(operand(0)),
+                        operand(0) ^= temporary(operand(0).size()),
+                        pf ^= intrinsic(),
+                        zf ^= operand(0) == constant(0),
+                        sf ^= signed_(operand(0)) < constant(0),
+                        of ^= intrinsic(),
+                        af ^= intrinsic(),
+                        less ^= ~(sf == of),
+                        less_or_equal ^= less | zf,
+                        below_or_equal ^= cf | zf\
+                ];
                 break;
-#undef add_bitness
             }
             case UD_Iclc: {
                 _[
@@ -199,16 +186,18 @@ public:
                 break;
             }
             case UD_Isahf: {
+#define extractFlag(offs) MemoryLocationExpression(X86Registers::ah()->memoryLocation().resized(1).shifted(offs))
                 _[
-                        sf ^= truncate(unsigned_(regizter(X86Registers::ah())) >> constant(6), 1),
-                        zf ^= truncate(unsigned_(regizter(X86Registers::ah())) >> constant(5), 1),
-                        af ^= truncate(unsigned_(regizter(X86Registers::ah())) >> constant(3), 1),
-                        pf ^= truncate(unsigned_(regizter(X86Registers::ah())) >> constant(1), 1),
-                        cf ^= truncate(unsigned_(regizter(X86Registers::ah())), 1),
+                        cf ^= MemoryLocationExpression(X86Registers::ah()->memoryLocation().resized(1)),
+                        pf ^= extractFlag(1),
+                        af ^= extractFlag(3),
+                        zf ^= extractFlag(5),
+                        sf ^= extractFlag(6),
                         less ^= ~(sf == of),
                         less_or_equal ^= less | zf,
                         below_or_equal ^= cf | zf
                 ];
+#undef extractFlag
                 break;
             }
             case UD_Ifnstsw: {

--- a/src/nc/common/Constexpr.hpp
+++ b/src/nc/common/Constexpr.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#if __cpp_constexpr >= 200704
+  #define CONSTEXPR constexpr
+#else
+  #define CONSTEXPR static inline
+#endif

--- a/src/nc/common/Constexpr.hpp
+++ b/src/nc/common/Constexpr.hpp
@@ -3,5 +3,5 @@
 #if __cpp_constexpr >= 200704
   #define CONSTEXPR constexpr
 #else
-  #define CONSTEXPR static inline
+  #define CONSTEXPR static
 #endif

--- a/src/nc/common/Constexpr.hpp
+++ b/src/nc/common/Constexpr.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#if __cpp_constexpr >= 200704
-  #define CONSTEXPR constexpr
-#else
-  #define CONSTEXPR static
-#endif

--- a/src/nc/core/likec/Simplifier.cpp
+++ b/src/nc/core/likec/Simplifier.cpp
@@ -346,6 +346,25 @@ std::unique_ptr<Expression> Simplifier::simplify(std::unique_ptr<BinaryOperator>
      */
     if (node->operatorKind() == BinaryOperator::ASSIGN) {
         if (VariableIdentifier *leftIdent = node->left()->as<VariableIdentifier>()) {
+             /*
+             * if the right hand side is a cast to the type of
+             * the left hand side, check to see if the right hand side expression
+             * will automatically be upgraded to the type of the left hand side
+             * only works for integer types.
+             */
+            if(node->left()->is<VariableIdentifier>() && node->right()->is<Typecast>()) {
+                auto dest = node->left()->as<VariableIdentifier>();
+                auto src = node->right()->as<Typecast>();
+                auto destType = dest->declaration()->type();
+                auto cstType = typeCalculator_.getType(src->operand().get());//src->type();
+                if(destType->isInteger() && cstType->isInteger() && destType->size() >= cstType->size()) {
+                    if(destType->as<IntegerType>()->isSigned() == cstType->as<IntegerType>()->isSigned()) {
+                        node->right() = std::move(src->operand());
+                        return std::move(simplify(std::move(node)));
+                    }
+                }
+            }
+            
             if (BinaryOperator *binary = node->right()->as<BinaryOperator>()) {
 
                 auto rewrite = [&](const Expression *left, const Expression *right) -> std::unique_ptr<Expression> {
@@ -400,7 +419,48 @@ std::unique_ptr<MemberAccessOperator> Simplifier::simplify(std::unique_ptr<Membe
 
 std::unique_ptr<Expression> Simplifier::simplify(std::unique_ptr<Typecast> node) {
     node->operand() = simplify(std::move(node->operand()));
+    /*
+     * simplify casts within casts
+     * woooooo! this works!
+     * and, it has a fairly noticeable impact
+     */
+    if(node->operand()->is<UnaryOperator>()
+                                          && node->type()->isInteger() &&
+            node->operand()->as<UnaryOperator>()->operatorKind() == UnaryOperator::DEREFERENCE) {
+        /*
+         * node's operand is dereference. node is a cast to an IntegerType
+         */
+        auto deref = node->operand()->as<UnaryOperator>();
 
+        if(deref->operand()->is<Typecast>()) {
+            /*
+             * we now know that this cast's operand is a dereference
+             * of a casted pointer
+             *
+             * we're going to check to see if the type of pointer it's casted to
+             * is compatible with the type this node is casting to
+             * i.e reinterpret_cast<int16_t>(*reinterpret_cast<uint16_t*>(&edi2))
+             * will become *reinterpret_cast<int16_t*>(&edi2)
+             */
+
+            auto innerCast = deref->operand()->as<Typecast>();
+            if (innerCast->type()->isPointer() && !node->type()->isPointer()) {
+                //inner cast is a pointer type
+                auto ptrType = innerCast->type()->as<PointerType>();
+                if (ptrType->pointeeType()->size() == node->type()->size()
+                    && ptrType->pointeeType()->isInteger()) {
+                    
+                    auto integerPointee = ptrType->pointeeType()->as<IntegerType>();
+
+                    deref->operand() =
+                    std::make_unique<Typecast>(Typecast::CastKind::REINTERPRET_CAST, new PointerType(
+                            innerCast->type()->size(), node->type()
+                    ), std::move(innerCast->operand()));
+                    return std::move(node->operand());
+                }
+            }
+        }
+    }
     /* Convert cast of pointer to a structure to a cast of pointer to its first field. */
     if (node->type()->isPointer() && !node->type()->isStructurePointer()) {
         if (auto pointerType = typeCalculator_.getType(node->operand().get())->as<PointerType>()) {

--- a/src/nc/core/likec/TypeCalculator.h
+++ b/src/nc/core/likec/TypeCalculator.h
@@ -45,6 +45,9 @@ public:
     const Type *getType(const VariableIdentifier *node);
     const Type *getType(const UndeclaredIdentifier *node);
     const Type *getBinaryOperatorType(int operatorKind, const Expression *left, const Expression *right);
+    Tree& getTree() {
+        return tree_;
+    }
 };
 
 } // namespace likec


### PR DESCRIPTION
The constraints on the new rules should avoid the introduction of any new issues. The typecast rule may leak memory as it allocates a new PointerType and the codebase doesn't make it very clear who has ownership of a type object.